### PR TITLE
🐛 Chromeバックエンドのx509取扱い修正

### DIFF
--- a/backend/handlers/chrome.go
+++ b/backend/handlers/chrome.go
@@ -76,6 +76,7 @@ func (h *ChromeHandler) GetAccessibleUsers(ctx context.Context, userID uuid.UUID
 func (h *ChromeHandler) HandleGetAssertion(c *gin.Context) {
 	type AssertionRequest struct {
 		UserID  uuid.UUID `json:"user_id"`
+		ClerkID string    `json:"clerk_id"`
 		ReqJson string    `json:"req_json"`
 	}
 	var req AssertionRequest
@@ -96,6 +97,7 @@ func (h *ChromeHandler) HandleGetAssertion(c *gin.Context) {
 func (h *ChromeHandler) HandleCreate(c *gin.Context) {
 	type CreateRequest struct {
 		UserID  uuid.UUID `json:"user_id"`
+		ClerkID string    `json:"clerk_id"`
 		ReqJson string    `json:"req_json"`
 	}
 	var req CreateRequest

--- a/backend/pkg/webauthn/create.go
+++ b/backend/pkg/webauthn/create.go
@@ -6,7 +6,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -230,7 +229,7 @@ func (p *PasskeyProcessor) ProcessCreate(
 	pkc.Response.AuthenticatorData = authB64
 	pkc.Response.Transports = []string{"internal"}
 	pkc.ClientExtensionResults = map[string]interface{}{}
-	pubDER, err := x509.MarshalPKIXPublicKey(&pskyInfo.PublicKey)
+	pubDER, err := ConvertX509PublicKeyToBytes(pskyInfo.PublicKey)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/backend/pkg/webauthn/x509_convert.go
+++ b/backend/pkg/webauthn/x509_convert.go
@@ -1,0 +1,38 @@
+package webauthn
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+)
+
+func ConvertX509PublicKeyToBytes(cert *ecdsa.PublicKey) ([]byte, error) {
+	key, err := x509.MarshalPKIXPublicKey(cert)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func ConvertX509PrivateKeyToBytes(cert *ecdsa.PrivateKey) ([]byte, error) {
+	key, err := x509.MarshalECPrivateKey(cert)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func ParseX509PublicKey(key []byte) (*ecdsa.PublicKey, error) {
+	cert, err := x509.ParsePKIXPublicKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return cert.(*ecdsa.PublicKey), nil
+}
+
+func ParseX509PrivateKey(key []byte) (*ecdsa.PrivateKey, error) {
+	cert, err := x509.ParseECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}

--- a/backend/pkg/webauthn/x509_parse_test.go
+++ b/backend/pkg/webauthn/x509_parse_test.go
@@ -1,0 +1,110 @@
+package webauthn
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+)
+
+// test parsing and decoding x509 certificate to []byte
+func TestConvertX509PrivateKeyToBytes(t *testing.T) {
+	// create a new private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Errorf("failed to generate key: %v", err)
+	}
+
+	// convert the private key to bytes
+	key, err := ConvertX509PrivateKeyToBytes(privateKey)
+	if err != nil {
+		t.Errorf("failed to convert private key to bytes: %v", err)
+	}
+
+	// parse the private key
+	parsedKey, err := ParseX509PrivateKey(key)
+	if err != nil {
+		t.Errorf("failed to parse private key: %v", err)
+	}
+
+	// compare the parsed key with the original key
+	if parsedKey.D.Cmp(privateKey.D) != 0 {
+		t.Errorf("parsed key does not match original key")
+	}
+}
+
+// test parsing and decoding x509 certificate to []byte
+func TestConvertX509PublicKeyToBytes(t *testing.T) {
+	// create a new private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Errorf("failed to generate key: %v", err)
+	}
+
+	// convert the private key to bytes
+	key, err := ConvertX509PublicKeyToBytes(privateKey.Public().(*ecdsa.PublicKey))
+	if err != nil {
+		t.Errorf("failed to convert private key to bytes: %v", err)
+	}
+
+	// parse the private key
+	parsedKey, err := ParseX509PublicKey(key)
+	if err != nil {
+		t.Errorf("failed to parse private key: %v", err)
+	}
+
+	// compare the parsed key with the original key
+	if parsedKey.X.Cmp(privateKey.X) != 0 {
+		t.Errorf("parsed key does not match original key")
+	}
+}
+
+func TestParseX509PublicKey(t *testing.T) {
+	// create a new private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Errorf("failed to generate key: %v", err)
+	}
+
+	// convert the private key to bytes
+	key, err := ConvertX509PublicKeyToBytes(privateKey.Public().(*ecdsa.PublicKey))
+	if err != nil {
+		t.Errorf("failed to convert private key to bytes: %v", err)
+	}
+
+	// parse the private key
+	parsedKey, err := ParseX509PublicKey(key)
+	if err != nil {
+		t.Errorf("failed to parse private key: %v", err)
+	}
+
+	// compare the parsed key with the original key
+	if parsedKey.X.Cmp(privateKey.X) != 0 {
+		t.Errorf("parsed key does not match original key")
+	}
+}
+
+func TestParseX509PrivateKey(t *testing.T) {
+	// create a new private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Errorf("failed to generate key: %v", err)
+	}
+
+	// convert the private key to bytes
+	key, err := ConvertX509PrivateKeyToBytes(privateKey)
+	if err != nil {
+		t.Errorf("failed to convert private key to bytes: %v", err)
+	}
+
+	// parse the private key
+	parsedKey, err := ParseX509PrivateKey(key)
+	if err != nil {
+		t.Errorf("failed to parse private key: %v", err)
+	}
+
+	// compare the parsed key with the original key
+	if parsedKey.D.Cmp(privateKey.D) != 0 {
+		t.Errorf("parsed key does not match original key")
+	}
+}


### PR DESCRIPTION
### **User description**
## PRで実装される機能


## PRで修正される機能


## レビューをお願いしたいポイント


___

### **PR Type**
- Bug fix
- Enhancement
- Tests



___

### **Description**
- Added `clerk_id` in assertion and create requests

- Replace x509.Marshal with conversion wrappers

- Refactored key generation and parsing calls

- Added tests for new conversion utilities


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome.go</strong><dd><code>Add clerk_id field in Chrome requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/handlers/chrome.go

<li>Added <code>clerk_id</code> field to assertion request<br> <li> Added <code>clerk_id</code> field to create request


</details>


  </td>
  <td><a href="https://github.com/a-company-jp/digi-baton/pull/58/files#diff-b8666f9386664885d5fcade253cab63c5f6905033aa0f8bdfa46086b22be04ff">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create.go</strong><dd><code>Use key conversion wrapper for public key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pkg/webauthn/create.go

<li>Replaced x509.MarshalPKIXPublicKey call<br> <li> Use ConvertX509PublicKeyToBytes for public keys


</details>


  </td>
  <td><a href="https://github.com/a-company-jp/digi-baton/pull/58/files#diff-060f89bdd1639425d4dacb4da40534030792bcbab3f98e78ea658ea17c917a82">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>store.go</strong><dd><code>Switch key conversion and parsing functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pkg/webauthn/store.go

<li>Renamed variable to newPrivKey for clarity<br> <li> Replaced x509.MarshalECPrivateKey with conversion helper<br> <li> Switched x509.Parse functions to wrappers for keys


</details>


  </td>
  <td><a href="https://github.com/a-company-jp/digi-baton/pull/58/files#diff-74c1325dfab44f929ba7c17e47bfbcc81084354bfd8ffa17662cb06c958a6ce0">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>x509_convert.go</strong><dd><code>Introduce x509 conversion helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pkg/webauthn/x509_convert.go

<li>Introduced ConvertX509PublicKeyToBytes and <br>ConvertX509PrivateKeyToBytes<br> <li> Added ParseX509PublicKey and ParseX509PrivateKey functions


</details>


  </td>
  <td><a href="https://github.com/a-company-jp/digi-baton/pull/58/files#diff-57b190f51b72be79d2df107d6ad9107e5b74fc422a770fb6741c5511d6d4aef7">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>x509_parse_test.go</strong><dd><code>Add tests for x509 conversion functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pkg/webauthn/x509_parse_test.go

<li>Added tests for private key conversion and parsing<br> <li> Added tests for public key conversion and parsing


</details>


  </td>
  <td><a href="https://github.com/a-company-jp/digi-baton/pull/58/files#diff-1ee86736c38eaf503877706b5405ee36dfe6c8bf9ff9eb6061b7c63b37fad9f2">+110/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>